### PR TITLE
Fix duplicate headers and missing page backgrounds

### DIFF
--- a/app/governance/page.tsx
+++ b/app/governance/page.tsx
@@ -9,7 +9,6 @@
  * the project’s treasury and roadmap. A list of key governance features is
  * presented in an easy‑to‑scan grid.
  */
-import Header from '../../components/Header';
 
 export default function GovernancePage() {
   // Section wrapper with background image and overlay. Accepts a relative
@@ -65,11 +64,8 @@ export default function GovernancePage() {
 
   return (
     <>
-      {/* Site header */}
-      <Header />
-
       {/* Hero section */}
-      <FramedSection bg="image17.png">
+      <FramedSection bg="assets/image17.png">
         <h1 className="text-4xl font-bold mb-4">Governance & DAO</h1>
         <p className="mb-4 leading-relaxed">
           AlynCoin’s governance is entirely on‑chain. Smart contracts handle proposal submission,

--- a/app/mining/page.tsx
+++ b/app/mining/page.tsx
@@ -10,7 +10,6 @@
  * follows the same visual style as the rest of the site with a dark theme
  * and a background image.
  */
-import Header from '../../components/Header';
 
 export default function MiningPage() {
   // Wrapper component to apply a background image with a tinted overlay.
@@ -64,11 +63,8 @@ export default function MiningPage() {
 
   return (
     <>
-      {/* Site header */}
-      <Header />
-
       {/* Hero */}
-      <FramedSection bg="image9.png">
+      <FramedSection bg="assets/image12.png">
         <h1 className="text-4xl font-bold mb-4">Mining & Emission</h1>
         <p className="mb-4 leading-relaxed">
           AlynCoin uses a hybrid proof‑of‑work consensus combining BLAKE3 and Keccak hashing. This

--- a/app/tokenomics/page.tsx
+++ b/app/tokenomics/page.tsx
@@ -10,7 +10,6 @@
  * table conveys the premine allocations, and a short summary explains
  * how rewards decay over time with a tail emission.
  */
-import Header from '../../components/Header';
 
 export default function TokenomicsPage() {
   // Reusable section wrapper that applies a background image with an
@@ -56,11 +55,8 @@ export default function TokenomicsPage() {
 
   return (
     <>
-      {/* Site header */}
-      <Header />
-
       {/* Hero section with background */}
-      <FramedSection bg="image16.png">
+      <FramedSection bg="assets/image16.png">
         <h1 className="text-4xl font-bold mb-4">Tokenomics</h1>
         <p className="mb-4 leading-relaxed">
           AlynCoin’s monetary policy balances scarcity, fairness and sustainability. The total supply


### PR DESCRIPTION
## Summary
- remove extra Header components from Mining, Governance and Tokenomics pages
- show unique background images for those sections using public assets

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Interactive configuration prompt)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897b402ee30832fa14f0b1b077f6e3f