### PR TITLE
Remove wallet coming soon chip from hero

### DIFF
--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -17,12 +17,21 @@ export default function DownloadsPage() {
 
       <div className="relative z-10 w-full flex justify-center">
         <div className="w-full max-w-[1200px] text-center">
-          <h2 className="text-4xl md:text-5xl font-extrabold mb-6 text-cyan-300">⬇️ Downloads Coming Soon</h2>
-          <p className="text-lg text-gray-300 mb-10 max-w-2xl mx-auto">
-            CLI binaries, mobile wallets, and GUI releases will be published once we launch the public testnet.
+          <h2 className="text-4xl md:text-5xl font-extrabold mb-6 text-cyan-300">⬇️ Download Center</h2>
+          <p className="text-lg text-gray-300 mb-10 max-w-3xl mx-auto">
+            Grab the brand-new Windows miner below, report any bugs you find, and stay tuned—our Mac miner ships in two
+            weeks alongside more tooling.
           </p>
 
           <div className="flex flex-col sm:flex-row justify-center items-center gap-4">
+            <a
+              href="https://github.com/ab1567/alyncoin-site/releases/download/v1.0.0/AlynCoin-win.exe"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-emerald-600 hover:bg-emerald-700 text-white px-6 py-3 rounded-xl shadow-md transition"
+            >
+              🪟 Download Windows Miner
+            </a>
             <a
               href="/downloads/AlynCoin_Whitepaper.pdf"
               target="_blank"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         {/* 🔔 Global Early Mining Notice */}
         <div className="fixed top-0 left-0 w-full bg-gradient-to-r from-cyan-700 via-black to-cyan-700 text-white text-sm md:text-base font-semibold py-2 z-50 overflow-hidden">
           <div className="animate-marquee whitespace-nowrap min-w-full px-4">
-            🚀 Early Mining Access Alert! Tag <span className="text-yellow-300 font-bold">#AlynCoin</span> on Twitter or Instagram to get whitelist access to early mining rewards & wallet features. 🧠 Don’t miss this chance to mine early!
+            Mac miner will be released in 2 weeks. Find bugs and help us.
           </div>
         </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -124,9 +124,14 @@ export default function Home() {
             >
               📄 View Whitepaper
             </a>
-            <span className="px-6 py-3 bg-gray-600 text-white rounded-xl opacity-60 cursor-not-allowed shadow-inner">
-              🍬 Wallet Coming Soon
-            </span>
+            <a
+              href="https://github.com/ab1567/alyncoin-site/releases/download/v1.0.0/AlynCoin-win.exe"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="px-6 py-3 bg-emerald-600 text-white rounded-xl hover:bg-emerald-700 transition shadow-md"
+            >
+              🪟 Download Windows Miner
+            </a>
           </div>
           <p className="mt-10 text-sm text-cyan-300 animate-bounce">↓ Scroll to Explore</p>
         </div>


### PR DESCRIPTION
## Summary
- remove the disabled wallet chip from the home hero since the miner is live

## Testing
- Not run (npm run lint prompts for ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_e_68d90af3ff58832f81cefec7b5b25eef