### PR TITLE
Refresh early mining banner messaging

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,14 +12,27 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en">
       <body className="bg-black text-white">
         {/* 🔔 Global Early Mining Notice */}
-        <div className="fixed top-0 left-0 w-full bg-gradient-to-r from-cyan-700 via-black to-cyan-700 text-white text-sm md:text-base font-semibold py-2 z-50 overflow-hidden">
-          <div className="animate-marquee whitespace-nowrap min-w-full px-4">
-            Mac miner will be released in 2 weeks. Find bugs and help us.
+        <div className="fixed top-0 left-0 w-full bg-gradient-to-r from-cyan-800/90 via-black to-cyan-800/90 text-white text-sm md:text-base font-semibold py-2 z-50 shadow-lg backdrop-blur">
+          <div className="mx-auto flex max-w-5xl items-center justify-center gap-3 px-4">
+            <span aria-hidden="true" className="hidden text-lg sm:inline">
+              🚀
+            </span>
+            <p className="flex-1 text-center">
+              <span className="text-cyan-300">Mac miner launches in two weeks.</span> Help us polish the release—download the
+              Windows build, hunt for bugs, and share your feedback.
+            </p>
+            <a
+              href="/downloads"
+              className="inline-flex items-center gap-1 rounded-full border border-cyan-400/70 bg-cyan-500/10 px-3 py-1 text-xs font-medium text-cyan-100 transition hover:border-cyan-300 hover:text-white hover:shadow-lg md:text-sm"
+            >
+              Download
+              <span aria-hidden="true">→</span>
+            </a>
           </div>
         </div>
 
         {/* Push content below banner */}
-        <div className="h-10"></div>
+        <div className="h-16"></div>
 
         <Header />
         <main className="tab-content">{children}</main>


### PR DESCRIPTION
## Summary
- replace the global announcement banner text with a more polished release message
- enhance the banner styling with iconography, backdrop blur, and a quick link to the downloads page
- adjust the layout spacing below the fixed banner to accommodate its updated height

## Testing
- npm run lint *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d92241d0cc832f9ba34deb178c0a5c