### PR TITLE
Update download links to latest release

### DIFF
--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -24,14 +24,26 @@ export default function DownloadsPage() {
           </p>
 
           <div className="flex flex-col sm:flex-row justify-center items-center gap-4">
-            <a
-              href="https://github.com/ab1567/alyncoin-site/releases/download/v1.0.0/AlynCoin-win.exe"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="bg-emerald-600 hover:bg-emerald-700 text-white px-6 py-3 rounded-xl shadow-md transition"
-            >
-              🪟 Download Windows Miner
-            </a>
+            <div className="flex flex-col items-center">
+              <a
+                href="https://github.com/ab1567/alyncoin-site/releases/latest/download/AlynCoin-win.exe"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="bg-emerald-600 hover:bg-emerald-700 text-white px-6 py-3 rounded-xl shadow-md transition"
+              >
+                🪟 Download Windows Miner
+              </a>
+              <small className="mt-1 text-sm text-gray-300">
+                <a
+                  href="https://github.com/ab1567/alyncoin-site/releases/latest"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-gray-100"
+                >
+                  Release notes
+                </a>
+              </small>
+            </div>
             <a
               href="/downloads/AlynCoin_Whitepaper.pdf"
               target="_blank"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -124,14 +124,26 @@ export default function Home() {
             >
               📄 View Whitepaper
             </a>
-            <a
-              href="https://github.com/ab1567/alyncoin-site/releases/download/v1.0.0/AlynCoin-win.exe"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="px-6 py-3 bg-emerald-600 text-white rounded-xl hover:bg-emerald-700 transition shadow-md"
-            >
-              🪟 Download Windows Miner
-            </a>
+            <div className="flex flex-col items-center">
+              <a
+                href="https://github.com/ab1567/alyncoin-site/releases/latest/download/AlynCoin-win.exe"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="px-6 py-3 bg-emerald-600 text-white rounded-xl hover:bg-emerald-700 transition shadow-md"
+              >
+                🪟 Download Windows Miner
+              </a>
+              <small className="mt-1 text-sm text-gray-300">
+                <a
+                  href="https://github.com/ab1567/alyncoin-site/releases/latest"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-gray-100"
+                >
+                  Release notes
+                </a>
+              </small>
+            </div>
           </div>
           <p className="mt-10 text-sm text-cyan-300 animate-bounce">↓ Scroll to Explore</p>
         </div>


### PR DESCRIPTION
## Summary
- point the homepage download button to the latest GitHub release and show a release notes link
- do the same for the downloads page so it always serves the newest build

## Testing
- npm run lint *(fails: prompts to configure ESLint interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68e81dd88078832f976077316b77f9f2