### PR TITLE
Update Windows miner download link

### DIFF
--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -26,7 +26,7 @@ export default function DownloadsPage() {
           <div className="flex flex-col sm:flex-row justify-center items-center gap-4">
             <div className="flex flex-col items-center">
               <a
-                href="https://github.com/ab1567/alyncoin-site/releases/latest/download/AlynCoin-win.exe"
+                href="https://github.com/ab1567/alyncoin-site/releases/download/v1.0.1.4/AlynCoin-win.exe"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="bg-emerald-600 hover:bg-emerald-700 text-white px-6 py-3 rounded-xl shadow-md transition"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -126,7 +126,7 @@ export default function Home() {
             </a>
             <div className="flex flex-col items-center">
               <a
-                href="https://github.com/ab1567/alyncoin-site/releases/latest/download/AlynCoin-win.exe"
+                href="https://github.com/ab1567/alyncoin-site/releases/download/v1.0.1.4/AlynCoin-win.exe"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="px-6 py-3 bg-emerald-600 text-white rounded-xl hover:bg-emerald-700 transition shadow-md"


### PR DESCRIPTION
## Summary
- update the Windows miner download buttons to point at the v1.0.1.4 release asset on the downloads and home pages

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f873265554832fb5d77d39c44050e2