### PR TITLE
Update Windows miner download link

### DIFF
--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -26,7 +26,7 @@ export default function DownloadsPage() {
           <div className="flex flex-col sm:flex-row justify-center items-center gap-4">
             <div className="flex flex-col items-center">
               <a
-                href="https://github.com/ab1567/alyncoin-site/releases/download/v1.0.1.4/AlynCoin-win.exe"
+                href="https://github.com/ab1567/alyncoin-site/releases/download/v1.0.1.5/AlynCoin-win.exe"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="bg-emerald-600 hover:bg-emerald-700 text-white px-6 py-3 rounded-xl shadow-md transition"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -126,7 +126,7 @@ export default function Home() {
             </a>
             <div className="flex flex-col items-center">
               <a
-                href="https://github.com/ab1567/alyncoin-site/releases/download/v1.0.1.4/AlynCoin-win.exe"
+                href="https://github.com/ab1567/alyncoin-site/releases/download/v1.0.1.5/AlynCoin-win.exe"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="px-6 py-3 bg-emerald-600 text-white rounded-xl hover:bg-emerald-700 transition shadow-md"


### PR DESCRIPTION
## Summary
- point the Windows miner download button on the home page to the v1.0.1.5 release asset
- update the downloads page to use the same refreshed Windows miner link

## Testing
- not run (lint command prompts for interactive configuration)


------
https://chatgpt.com/codex/tasks/task_e_68f8804c11f0832fb5169a545cc653a9