### PR TITLE
Normalize CTA layout across pages

### DIFF
--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 export default function DownloadsPage() {
+  const ctaBase =
+    'inline-flex items-center justify-center px-6 py-3 rounded-xl shadow-md transition whitespace-nowrap text-white text-center';
+
   return (
     <section
       className="relative text-white py-32 px-6 min-h-screen"
@@ -19,23 +22,23 @@ export default function DownloadsPage() {
         <div className="w-full max-w-[1200px] text-center">
           <h2 className="text-4xl md:text-5xl font-extrabold mb-6 text-cyan-300">⬇️ Download Center</h2>
           <p className="text-lg text-gray-300 mb-10 max-w-3xl mx-auto">
-            Grab the brand-new Windows miner below, report any bugs you find, and stay tuned—our Mac miner ships in two
-            weeks alongside more tooling.
+            Grab the brand-new Windows miner below, explore the open source repo, report any bugs you find, and stay
+            tuned—our Mac miner ships in two weeks alongside more tooling.
           </p>
 
           <div className="flex flex-col sm:flex-row justify-center items-center gap-4">
             <div className="flex flex-col items-center">
               <a
-                href="https://github.com/ab1567/alyncoin-site/releases/download/v1.0.1.5/AlynCoin-win.exe"
+                href="https://github.com/ab1567/AlynCoin-public/releases/latest/download/AlynCoin-win.exe"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="bg-emerald-600 hover:bg-emerald-700 text-white px-6 py-3 rounded-xl shadow-md transition"
+                className={`${ctaBase} bg-emerald-600 hover:bg-emerald-700`}
               >
                 🪟 Download Windows Miner
               </a>
               <small className="mt-1 text-sm text-gray-300">
                 <a
-                  href="https://github.com/ab1567/alyncoin-site/releases/latest"
+                  href="https://github.com/ab1567/AlynCoin-public/releases/latest"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="underline hover:text-gray-100"
@@ -45,22 +48,30 @@ export default function DownloadsPage() {
               </small>
             </div>
             <a
+              href="https://github.com/ab1567/AlynCoin-public"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`${ctaBase} bg-gradient-to-r from-cyan-500 to-blue-600 hover:from-cyan-400 hover:to-blue-500`}
+            >
+              🌐 Open Source Repo
+            </a>
+            <a
               href="/downloads/AlynCoin_Whitepaper.pdf"
               target="_blank"
-              className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded-xl shadow-md transition"
+              className={`${ctaBase} bg-blue-600 hover:bg-blue-700`}
             >
               📄 View Whitepaper
             </a>
             <a
               href="/downloads/pitch_deck.pdf"
               target="_blank"
-              className="bg-green-600 hover:bg-green-700 text-white px-6 py-3 rounded-xl shadow-md transition"
+              className={`${ctaBase} bg-green-600 hover:bg-green-700`}
             >
               📘 View Pitch Deck
             </a>
             <a
               href="/"
-              className="bg-gray-700 hover:bg-gray-600 text-white px-6 py-3 rounded-xl shadow-md transition"
+              className={`${ctaBase} bg-gray-700 hover:bg-gray-600`}
             >
               🔙 Back to Home
             </a>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -91,6 +91,9 @@ export default function Home() {
     },
   ];
 
+  const ctaBase =
+    'inline-flex items-center justify-center px-6 py-3 rounded-xl shadow-md transition whitespace-nowrap text-white text-center';
+
   return (
     <>
       {/* HERO */}
@@ -114,28 +117,28 @@ export default function Home() {
           <div className="flex flex-wrap justify-center gap-4">
             <a
               href="/downloads/AlyncoinGPTresearch.pdf"
-              className="px-6 py-3 bg-gradient-to-r from-purple-500 to-pink-600 text-white rounded-xl hover:from-purple-600 hover:to-pink-700 transition shadow-md"
+              className={`${ctaBase} bg-gradient-to-r from-purple-500 to-pink-600 hover:from-purple-600 hover:to-pink-700`}
             >
               🧠 GPT Research
             </a>
             <a
               href="/downloads/AlynCoin_Whitepaper.pdf"
-              className="px-6 py-3 bg-blue-600 text-white rounded-xl hover:bg-blue-700 transition shadow-md animate-pulse"
+              className={`${ctaBase} bg-blue-600 hover:bg-blue-700 animate-pulse`}
             >
               📄 View Whitepaper
             </a>
             <div className="flex flex-col items-center">
               <a
-                href="https://github.com/ab1567/alyncoin-site/releases/download/v1.0.1.5/AlynCoin-win.exe"
+                href="https://github.com/ab1567/AlynCoin-public/releases/latest/download/AlynCoin-win.exe"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="px-6 py-3 bg-emerald-600 text-white rounded-xl hover:bg-emerald-700 transition shadow-md"
+                className={`${ctaBase} bg-emerald-600 hover:bg-emerald-700`}
               >
                 🪟 Download Windows Miner
               </a>
               <small className="mt-1 text-sm text-gray-300">
                 <a
-                  href="https://github.com/ab1567/alyncoin-site/releases/latest"
+                  href="https://github.com/ab1567/AlynCoin-public/releases/latest"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="underline hover:text-gray-100"
@@ -144,6 +147,14 @@ export default function Home() {
                 </a>
               </small>
             </div>
+            <a
+              href="https://github.com/ab1567/AlynCoin-public"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`${ctaBase} bg-gradient-to-r from-cyan-500 to-blue-600 hover:from-cyan-400 hover:to-blue-500`}
+            >
+              🌐 Open Source Repo
+            </a>
           </div>
           <p className="mt-10 text-sm text-cyan-300 animate-bounce">↓ Scroll to Explore</p>
         </div>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,7 +1,15 @@
 export default function Footer() {
   return (
     <footer className="text-center py-6 px-4 mt-10 border-t border-gray-800 bg-black text-gray-500 text-sm">
-      © 2025 AlynCoin. Built with quantum resistance in mind.
+      © 2025 AlynCoin. Built with quantum resistance in mind.{' '}
+      <a
+        href="https://github.com/ab1567/AlynCoin-public"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-cyan-400 hover:text-cyan-300"
+      >
+        View the open source repo.
+      </a>
     </footer>
   );
 }


### PR DESCRIPTION
## Summary
- introduce a shared CTA base class in the hero to keep every button the same height and alignment
- reuse the same base styling on the downloads page so the open source repo link matches the surrounding call-to-action buttons

## Testing
- npm run lint *(fails: prompts for ESLint configuration via Next.js)*

------
https://chatgpt.com/codex/tasks/task_e_68fd00789aa8832fadc72f15fd4938ed